### PR TITLE
require_relative for cewl_lib

### DIFF
--- a/cewl.rb
+++ b/cewl.rb
@@ -39,7 +39,7 @@ rescue LoadError => e
 	end
 end
 
-require './cewl_lib'
+require_relative 'cewl_lib'
 
 # Doing this so I can override the allowed? function which normally checks
 # the robots.txt file


### PR DESCRIPTION
Allows cewl to be called outside its directory. Fixes https://github.com/trustedsec/ptf/issues/380