### PR TITLE
Allow to pass a pattern the url path must match to be followed

### DIFF
--- a/README
+++ b/README
@@ -27,6 +27,10 @@ GitHub: https://github.com/digininja/CeWL
 Change Log
 ==========
 
+Version 5.4.7
+-------------
+Added the --allowed parameter to limit crawling to URLs matching the passed RegEx
+
 Version 5.4.6
 -------------
 Added the --lowercase parameter to convert all letters to lower case

--- a/cewl.rb
+++ b/cewl.rb
@@ -469,6 +469,7 @@ opts = GetoptLong.new(
 		['--no-words', "-n", GetoptLong::NO_ARGUMENT],
 		['--offsite', "-o", GetoptLong::NO_ARGUMENT],
 		['--exclude', GetoptLong::REQUIRED_ARGUMENT],
+		['--allowed', GetoptLong::REQUIRED_ARGUMENT],
 		['--write', "-w", GetoptLong::REQUIRED_ARGUMENT],
 		['--ua', "-u", GetoptLong::REQUIRED_ARGUMENT],
 		['--meta-temp-dir', GetoptLong::REQUIRED_ARGUMENT],
@@ -503,6 +504,7 @@ def usage
 	-m, --min_word_length: Minimum word length, default 3.
 	-o, --offsite: Let the spider visit other sites.
 	--exclude: A file containing a list of paths to exclude
+	--allowed: A regex pattern that path must match to be followed
 	-w, --write: Write the output to the file.
 	-u, --ua <agent>: User agent to send.
 	-n, --no-words: Don't output the wordlist.
@@ -547,6 +549,7 @@ email_outfile = nil
 meta_outfile = nil
 offsite = false
 exclude_array = []
+allowed_pattern = nil
 depth = 2
 min_word_length = 3
 email = false
@@ -636,6 +639,8 @@ begin
 						# puts "Excluding #{ line.strip}"
 					end
 				end
+			when '--allowed'
+				allowed_pattern = Regexp.new(arg)
 			when '--ua'
 				ua = arg
 			when '--debug'
@@ -796,6 +801,11 @@ catch :ctrl_c do
 						puts "Found: #{a_url_parsed.path}" if @debug
 						if exclude_array.include?(a_url_parsed.path)
 							puts "Excluding path: #{a_url_parsed.path}" if verbose
+							allow = false
+						end
+
+						if allowed_pattern && !a_url_parsed.path.match(allowed_pattern)
+							puts "Excluding path: #{a_url_parsed.path} based on allowed pattern" if verbose
 							allow = false
 						end
 					end

--- a/cewl.rb
+++ b/cewl.rb
@@ -16,7 +16,7 @@
 # Licence:: CC-BY-SA 2.0 or GPL-3+
 #
 
-VERSION = "5.4.6 (Exclusion)"
+VERSION = "5.4.7 (Exclusion)"
 
 puts "CeWL #{VERSION} Robin Wood (robin@digi.ninja) (https://digi.ninja/)\n"
 


### PR DESCRIPTION
Sometimes excludes is not practical (like when crawling a specific user in a platform, ie. github.com/digininja/ or medium.com/@bobytables) this allows to easily constrain the crawling by the url path pattern.

