### PR TITLE
Update fab.rb

### DIFF
--- a/fab.rb
+++ b/fab.rb
@@ -29,7 +29,7 @@
 
 require "rubygems"
 require 'getoptlong'
-require "./cewl_lib.rb"
+require_relative "./cewl_lib.rb"
 
 opts = GetoptLong.new(
 	[ '--help', '-h', GetoptLong::NO_ARGUMENT ],


### PR DESCRIPTION
We better use "require_relative" keyword which uses relative path to load the library. So, we'll be able to load the library when using symbolic links in OS PATH