### PR TITLE
bump Dockerfile to ruby 2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5-alpine
+FROM ruby:2.6-alpine
 
 ENV RUBYOPT "rubygems"
 


### PR DESCRIPTION
on 2.5, `gem install bundler` was throwing the following error, so `docker build .` wasn't working:

```
+ gem install bundler
ERROR:  Error installing bundler:
	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.3.26. Try installing it with `gem install bundler -v 2.3.26`
	bundler requires Ruby version >= 2.6.0. The current ruby version is 2.5.9.229.

```