### PR TITLE
bump ruby version to fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5-alpine
+FROM ruby:3-alpine
 
 ENV RUBYOPT "rubygems"
 


### PR DESCRIPTION
Docker build is using an older Ruby which doesn't build properly. Newer version fixes all errors.