### PR TITLE
Add missing `r` to RUBYOPT in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3-alpine
 
-ENV RUBYOPT "rubygems"
+ENV RUBYOPT "rrubygems"
 
 COPY Gemfile /usr/src/CeWL/
 WORKDIR /usr/src/CeWL


### PR DESCRIPTION
I tried to build the docker image and got this error. After digging on Google and Github, I found that the `-rubygems` flag is deprecated as of Ruby 2.5. After adding the missing `r` to `RUBYOPT`, I successfully built the container image.

```
12.89 + gem install bundler
12.94 <internal:/usr/local/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require': cannot load such file -- ubygems (LoadError)
12.94 Did you mean?  rubygems
12.94 	from <internal:/usr/local/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
------
Dockerfile:9
--------------------
   8 |     RUN apk add gcompat
   9 | >>> RUN set -ex \
  10 | >>>     && apk add  --no-cache --virtual .build-deps build-base \
  11 | >>>     && gem install bundler \
  12 | >>>     && bundle install \
  13 | >>>     && apk del .build-deps
  14 |
--------------------
ERROR: failed to solve: process "/bin/sh -c set -ex     && apk add  --no-cache --virtual .build-deps build-base     && gem install bundler     && bundle install     && apk del .build-deps" did not complete successfully: exit code: 1
```

https://github.com/rubygems/rubygems/issues/2393#issuecomment-421626674

@loris-intergalactique can you please review the MR?